### PR TITLE
Use Python >=3.10 syntax

### DIFF
--- a/src/autopdfparse/models.py
+++ b/src/autopdfparse/models.py
@@ -33,7 +33,7 @@ class ParsedPDFResult:
         pages: List of parsed PDF pages
     """
 
-    pages: List[PDFPage]
+    pages: list[PDFPage]
 
     def get_all_content(self) -> str:
         """Returns all page content concatenated into a single string."""

--- a/src/autopdfparse/providers/anthropic.py
+++ b/src/autopdfparse/providers/anthropic.py
@@ -183,7 +183,7 @@ class AnthropicVisionService(VisionService):
                 )
 
                 text_content = message.content[0].text  # type: ignore
-                result = VisualModelDecision(**json_repair.loads((text_content)))  # type: ignore
+                result = VisualModelDecision(**json_repair.loads(text_content))  # type: ignore
                 return result.content_is_layout_dependent
         except Exception:
             # Default to True on failure to ensure we don't miss layout-dependent content

--- a/src/autopdfparse/services/parser.py
+++ b/src/autopdfparse/services/parser.py
@@ -85,13 +85,13 @@ class PDFParser:
         """
         try:
             document = pymupdf.open(stream=self.pdf_content)
-            images: List[pymupdf.Pixmap] = [page.get_pixmap() for page in document]  # type: ignore
-            page_texts: List[str] = [page.get_text() for page in document]  # type: ignore
+            images: list[pymupdf.Pixmap] = [page.get_pixmap() for page in document]  # type: ignore
+            page_texts: list[str] = [page.get_text() for page in document]  # type: ignore
             if not images:
                 return ParsedPDFResult(pages=[])
 
             async with asyncio.TaskGroup() as tg:
-                tasks: List[asyncio.Task[ParsedData]] = []
+                tasks: list[asyncio.Task[ParsedData]] = []
                 for i, (text, image) in enumerate(zip(page_texts, images)):
                     tasks.append(tg.create_task(self._parse_page(text, image, i + 1)))
             results = [task.result() for task in tasks]

--- a/src/autopdfparse/sync/providers/anthropic.py
+++ b/src/autopdfparse/sync/providers/anthropic.py
@@ -170,7 +170,7 @@ class AnthropicVisionService(VisionService):
             )
 
             text_content = message.content[0].text  # type: ignore
-            result = VisualModelDecision(**json_repair.loads((text_content)))  # type: ignore
+            result = VisualModelDecision(**json_repair.loads(text_content))  # type: ignore
             return result.content_is_layout_dependent
         except Exception:
             # Default to True on failure to ensure we don't miss layout-dependent content

--- a/src/autopdfparse/sync/services/parser.py
+++ b/src/autopdfparse/sync/services/parser.py
@@ -84,8 +84,8 @@ class PDFParser:
         """
         try:
             document = pymupdf.open(stream=self.pdf_content)
-            images: List[pymupdf.Pixmap] = [page.get_pixmap() for page in document]  # type: ignore
-            page_texts: List[str] = [page.get_text() for page in document]  # type: ignore
+            images: list[pymupdf.Pixmap] = [page.get_pixmap() for page in document]  # type: ignore
+            page_texts: list[str] = [page.get_text() for page in document]  # type: ignore
             if not images:
                 return ParsedPDFResult(pages=[])
 

--- a/tests/integration/test_providers.py
+++ b/tests/integration/test_providers.py
@@ -17,7 +17,7 @@ import pytest
 from autopdfparse.providers import AnthropicParser, GeminiParser, OpenAIParser
 
 
-def get_api_key(env_var: str) -> Optional[str]:
+def get_api_key(env_var: str) -> str | None:
     """Get API key from environment variable if it exists."""
 
     return os.environ.get(env_var)

--- a/tests/utils/local_vision.py
+++ b/tests/utils/local_vision.py
@@ -17,7 +17,7 @@ class LocalVisionService:
     of cloud vision services without making actual API calls.
     """
 
-    layout_dependent_pattern: Optional[str] = None
+    layout_dependent_pattern: str | None = None
     content_responses: dict[str, str] = field(default_factory=lambda: {})
 
     def _hash_image(self, image: str) -> str:
@@ -76,7 +76,7 @@ class LocalVisionService:
 class LocalSyncVisionService:
     """Synchronous version of LocalVisionService for sync API testing."""
 
-    layout_dependent_pattern: Optional[str] = None
+    layout_dependent_pattern: str | None = None
     content_responses: dict[str, str] = field(default_factory=lambda: {})
 
     def _hash_image(self, image: str) -> str:


### PR DESCRIPTION
The project only supports 3.12, so there's no reason to use older syntax
